### PR TITLE
allow format .cjs, .mts and .cts files

### DIFF
--- a/src/extAlias.ts
+++ b/src/extAlias.ts
@@ -1,0 +1,8 @@
+'use strict';
+
+// a file extension alias mapping used when config 'assumeFilename' is empty
+export const EXT_ALIAS = {
+  '.cjs': '.js',
+  '.cts': '.ts',
+  '.mts': '.ts',
+};


### PR DESCRIPTION
Clang-Format officially only supports `.mjs .js .ts` for JavaScript language. (see [doc](https://clang.llvm.org/docs/ClangFormat.html))

This change adds .cjs, .mts and .cts support for vscode clang-format extension