### PR TITLE
Update settings config for format on save

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,14 @@ vscode settings.json file:
 
 ```json
 {
-    "editor.formatOnSave": true
+    "[cpp]": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "xaver.clang-format"
+    },
+    "[c]": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "xaver.clang-format"
+    }
 }
 ```
 


### PR DESCRIPTION
Hi there,

I was having trouble using the original suggestion to actually format my codebase, and I found that the change proposed here allowed me to format on save again.

Perhaps this is due to some change in a more recent vscode?

Regardless, I hope this may help